### PR TITLE
feat: add full display property for handlebars chart

### DIFF
--- a/superset-frontend/plugins/plugin-chart-handlebars/src/Handlebars.tsx
+++ b/superset-frontend/plugins/plugin-chart-handlebars/src/Handlebars.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { styled } from '@superset-ui/core';
+import { styled, css } from '@superset-ui/core';
 import React, { createRef } from 'react';
 import { HandlebarsViewer } from './components/Handlebars/HandlebarsViewer';
 import { HandlebarsProps, HandlebarsStylesProps } from './types';
@@ -27,6 +27,14 @@ const Styles = styled.div<HandlebarsStylesProps>`
   height: ${({ height }) => height}px;
   width: ${({ width }) => width}px;
   overflow: auto;
+
+  ${props =>
+    !!props?.fullDisplay &&
+    css`
+      height: 100%;
+      width: 100%;
+      padding: 0;
+    `};
 `;
 
 export default function Handlebars(props: HandlebarsProps) {
@@ -42,7 +50,12 @@ export default function Handlebars(props: HandlebarsProps) {
   const rootElem = createRef<HTMLDivElement>();
 
   return (
-    <Styles ref={rootElem} height={height} width={width}>
+    <Styles
+      ref={rootElem}
+      height={height}
+      width={width}
+      fullDisplay={formData?.fullDisplay}
+    >
       <HandlebarsViewer data={{ data }} templateSource={templateSource} />
     </Styles>
   );

--- a/superset-frontend/plugins/plugin-chart-handlebars/src/plugin/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-handlebars/src/plugin/controlPanel.tsx
@@ -44,9 +44,15 @@ import {
 } from './controls/pagination';
 import { queryModeControlSetItem } from './controls/queryMode';
 import { styleControlSetItem } from './controls/style';
+import { fullDisplayControl } from './controls/fullDisplay';
 
 const config: ControlPanelConfig = {
   controlPanelSections: [
+    {
+      label: t('Full display'),
+      expanded: true,
+      controlSetRows: [[fullDisplayControl]],
+    },
     {
       label: t('Query'),
       expanded: true,

--- a/superset-frontend/plugins/plugin-chart-handlebars/src/plugin/controls/fullDisplay.tsx
+++ b/superset-frontend/plugins/plugin-chart-handlebars/src/plugin/controls/fullDisplay.tsx
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { ControlSetItem } from '@superset-ui/chart-controls';
+
+export const fullDisplayControl: ControlSetItem = {
+  name: 'fullDisplay',
+  config: {
+    type: 'CheckboxControl',
+    label: 'Full display',
+    renderTrigger: true,
+    default: false,
+    description: 'Slice take full space (No header, only controls)',
+  },
+};

--- a/superset-frontend/plugins/plugin-chart-handlebars/src/types.ts
+++ b/superset-frontend/plugins/plugin-chart-handlebars/src/types.ts
@@ -27,6 +27,7 @@ import {
 export interface HandlebarsStylesProps {
   height: number;
   width: number;
+  fullDisplay?: boolean;
 }
 
 interface HandlebarsCustomizeProps {

--- a/superset-frontend/src/components/Chart/Chart.jsx
+++ b/superset-frontend/src/components/Chart/Chart.jsx
@@ -26,6 +26,7 @@ import {
   logging,
   styled,
   t,
+  css,
 } from '@superset-ui/core';
 import { PLACEHOLDER_DATASOURCE } from 'src/dashboard/constants';
 import Loading from 'src/components/Loading';
@@ -127,6 +128,20 @@ const Styles = styled.div`
     .alert {
       margin: ${({ theme }) => theme.gridUnit * 2}px;
     }
+
+    ${props =>
+      !!props?.fullDisplay &&
+      css`
+        height: 100%;
+
+        & > div {
+          height: 100%;
+
+          & > div {
+            height: 100%;
+          }
+        }
+      `};
   }
 `;
 
@@ -310,6 +325,7 @@ class Chart extends React.PureComponent {
           data-test="chart-container"
           height={height}
           width={width}
+          fullDisplay={!!this.props.formData?.fullDisplay}
         >
           <div className="slice_container" data-test="slice-container">
             {this.props.isInView ||

--- a/superset-frontend/src/dashboard/components/SliceHeader/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeader/index.tsx
@@ -65,6 +65,12 @@ const CrossFilterIcon = styled(Icons.ApartmentOutlined)`
   `}
 `;
 
+const NoHeaderStyles = styled.div`
+  position: absolute;
+  top: 20px;
+  right: 20px;
+`;
+
 const ChartHeaderStyles = styled.div`
   ${({ theme }) => css`
     font-size: ${theme.typography.sizes.l}px;
@@ -207,6 +213,66 @@ const SliceHeader: FC<SliceHeaderProps> = ({
 
   const exploreUrl = `/explore/?dashboard_page_id=${dashboardPageId}&slice_id=${slice.slice_id}`;
 
+  const HeaderControls = () => (
+    <>
+      {SliceHeaderExtension && (
+        <SliceHeaderExtension
+          sliceId={slice.slice_id}
+          dashboardId={dashboardId}
+        />
+      )}
+      {crossFilterValue && (
+        <Tooltip
+          placement="top"
+          title={t(
+            'This chart applies cross-filters to charts whose datasets contain columns with the same name.',
+          )}
+        >
+          <CrossFilterIcon iconSize="m" />
+        </Tooltip>
+      )}
+      {!uiConfig.hideChartControls && (
+        <SliceHeaderControls
+          slice={slice}
+          isCached={isCached}
+          isExpanded={isExpanded}
+          cachedDttm={cachedDttm}
+          updatedDttm={updatedDttm}
+          toggleExpandSlice={toggleExpandSlice}
+          forceRefresh={forceRefresh}
+          logExploreChart={logExploreChart}
+          logEvent={logEvent}
+          exportCSV={exportCSV}
+          exportFullCSV={exportFullCSV}
+          exportXLSX={exportXLSX}
+          exportFullXLSX={exportFullXLSX}
+          supersetCanExplore={supersetCanExplore}
+          supersetCanShare={supersetCanShare}
+          supersetCanCSV={supersetCanCSV}
+          componentId={componentId}
+          dashboardId={dashboardId}
+          addSuccessToast={addSuccessToast}
+          addDangerToast={addDangerToast}
+          handleToggleFullSize={handleToggleFullSize}
+          isFullSize={isFullSize}
+          isDescriptionExpanded={isExpanded}
+          chartStatus={chartStatus}
+          formData={formData}
+          exploreUrl={exploreUrl}
+          crossFiltersEnabled={isCrossFiltersEnabled}
+        />
+      )}
+    </>
+  );
+
+  if (formData?.fullDisplay) {
+    return (
+      <NoHeaderStyles className="slice-no-header">
+        {!editMode && <HeaderControls />}
+      </NoHeaderStyles>
+    );
+  }
+
   return (
     <ChartHeaderStyles data-test="slice-header" ref={innerRef}>
       <div className="header">
@@ -252,59 +318,7 @@ const SliceHeader: FC<SliceHeaderProps> = ({
             </Tooltip>
           )}
         </div>
-        <div className="header-controls">
-          {!editMode && (
-            <>
-              {SliceHeaderExtension && (
-                <SliceHeaderExtension
-                  sliceId={slice.slice_id}
-                  dashboardId={dashboardId}
-                />
-              )}
-              {crossFilterValue && (
-                <Tooltip
-                  placement="top"
-                  title={t(
-                    'This chart applies cross-filters to charts whose datasets contain columns with the same name.',
-                  )}
-                >
-                  <CrossFilterIcon iconSize="m" />
-                </Tooltip>
-              )}
-              {!uiConfig.hideChartControls && (
-                <SliceHeaderControls
-                  slice={slice}
-                  isCached={isCached}
-                  isExpanded={isExpanded}
-                  cachedDttm={cachedDttm}
-                  updatedDttm={updatedDttm}
-                  toggleExpandSlice={toggleExpandSlice}
-                  forceRefresh={forceRefresh}
-                  logExploreChart={logExploreChart}
-                  logEvent={logEvent}
-                  exportCSV={exportCSV}
-                  exportFullCSV={exportFullCSV}
-                  exportXLSX={exportXLSX}
-                  exportFullXLSX={exportFullXLSX}
-                  supersetCanExplore={supersetCanExplore}
-                  supersetCanShare={supersetCanShare}
-                  supersetCanCSV={supersetCanCSV}
-                  componentId={componentId}
-                  dashboardId={dashboardId}
-                  addSuccessToast={addSuccessToast}
-                  addDangerToast={addDangerToast}
-                  handleToggleFullSize={handleToggleFullSize}
-                  isFullSize={isFullSize}
-                  isDescriptionExpanded={isExpanded}
-                  chartStatus={chartStatus}
-                  formData={formData}
-                  exploreUrl={exploreUrl}
-                  crossFiltersEnabled={isCrossFiltersEnabled}
-                />
-              )}
-            </>
-          )}
-        </div>
+        <div className="header-controls">{!editMode && <HeaderControls />}</div>
       </div>
       {!uiConfig.hideChartControls && <FiltersBadge chartId={slice.slice_id} />}
     </ChartHeaderStyles>

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
@@ -19,7 +19,7 @@
 import cx from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { styled, t, logging } from '@superset-ui/core';
+import { styled, t, logging, css } from '@superset-ui/core';
 import { debounce, isEqual } from 'lodash';
 import { withRouter } from 'react-router-dom';
 
@@ -119,6 +119,18 @@ const SliceContainer = styled.div`
   display: flex;
   flex-direction: column;
   max-height: 100%;
+
+  ${props =>
+    !!props?.fullDisplay &&
+    css`
+      height: 100%;
+
+      & .chart-container,
+      & .dashboard-chart {
+        padding: 0;
+        height: 100%;
+      }
+    `};
 `;
 
 class Chart extends React.Component {
@@ -428,6 +440,7 @@ class Chart extends React.Component {
         data-test-chart-id={id}
         data-test-viz-type={slice.viz_type}
         data-test-chart-name={slice.slice_name}
+        fullDisplay={!!formData?.fullDisplay}
       >
         <SliceHeader
           innerRef={this.setHeaderRef}


### PR DESCRIPTION
### SUMMARY
Added additional property Full Display that will remove header and move controls to the top right corner. For now it is applied only for handlebars, but it potentially can be extended for other charts.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="1476" alt="image" src="https://github.com/user-attachments/assets/cf0d2f18-dc1c-4194-9c79-f44ab6339a14">
After:
<img width="1483" alt="image" src="https://github.com/user-attachments/assets/005badb6-610c-4d4d-9227-503c275940b6">


### TESTING INSTRUCTIONS
Select Handlebars chart, go to Customize, set checkbox for property Full Display

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
